### PR TITLE
Extract filtering helper and persist sent post IDs

### DIFF
--- a/internal/run.go
+++ b/internal/run.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"path/filepath"
 	"time"
 
 	"github.com/bakkerme/ai-news-processor/internal/bench"
@@ -98,7 +99,11 @@ func Run() {
 	}
 
 	// Process each persona
-	sentLogPath := "sent_post_ids.json"
+	sentLogBase := s.SentLogBasePath
+	if sentLogBase == "" {
+		sentLogBase = "."
+	}
+	sentLogPath := filepath.Join(sentLogBase, "sent_post_ids.json")
 	sentIDs, err := sentlog.LoadSentIDs(sentLogPath)
 	if err != nil {
 		log.Printf("Warning: could not load sent log: %v", err)

--- a/internal/sentlog/sentlog.go
+++ b/internal/sentlog/sentlog.go
@@ -1,0 +1,61 @@
+package sentlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// LoadSentIDs loads a set of sent item IDs from disk.
+// If the file does not exist, an empty set is returned.
+func LoadSentIDs(path string) (map[string]struct{}, error) {
+	ids := make(map[string]struct{})
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ids, nil
+		}
+		return nil, fmt.Errorf("could not read sent log: %w", err)
+	}
+
+	var list []string
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, fmt.Errorf("could not parse sent log: %w", err)
+	}
+	for _, id := range list {
+		if id == "" {
+			continue
+		}
+		ids[id] = struct{}{}
+	}
+	return ids, nil
+}
+
+// SaveSentIDs persists the sent item IDs to disk as a JSON array.
+func SaveSentIDs(path string, ids map[string]struct{}) error {
+	list := make([]string, 0, len(ids))
+	for id := range ids {
+		list = append(list, id)
+	}
+	sort.Strings(list)
+
+	payload, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return fmt.Errorf("could not encode sent log: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("could not create sent log directory: %w", err)
+		}
+	}
+
+	if err := os.WriteFile(path, payload, 0644); err != nil {
+		return fmt.Errorf("could not write sent log: %w", err)
+	}
+
+	return nil
+}

--- a/internal/specification/specification.go
+++ b/internal/specification/specification.go
@@ -36,6 +36,8 @@ type Specification struct {
 
 	PersonasPath string
 
+	SentLogBasePath string
+
 	AuditServiceUrl string
 
 	SendBenchmarkToAuditService bool
@@ -150,6 +152,8 @@ func GetConfig() (*Specification, error) {
 		QualityFilterThreshold: getIntEnv("ANP_QUALITY_FILTER_THRESHOLD", 10),
 
 		PersonasPath: os.Getenv("ANP_PERSONAS_PATH"),
+
+		SentLogBasePath: os.Getenv("ANP_SENT_LOG_BASE_PATH"),
 
 		AuditServiceUrl: os.Getenv("ANP_AUDIT_SERVICE_URL"),
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate emails by persisting which post IDs have already been sent across runs.
- Improve readability and maintainability by moving inline filtering logic into a dedicated helper.
- Surface warnings when the sent-log cannot be loaded or persisted so issues are visible in logs.
- Keep the sent ID storage format simple and human-readable as a JSON array.

### Description
- Add a new `internal/sentlog` package with `LoadSentIDs` and `SaveSentIDs` to read/write `sent_post_ids.json` as a JSON array.
- Load the sent log at startup via `sentlog.LoadSentIDs` and fall back to an empty set with a logged warning on error.
- Replace inline filtering with a new helper `filterUnsentItems` and call it after `llm.FilterRelevantItems`.
- After successful `email.RenderAndSend`, update the in-memory set and persist it using `sentlog.SaveSentIDs`, logging a warning if persistence fails.

### Testing
- No automated tests were run for these changes.
- The code was formatted with `gofmt` as part of the rollout but no test suite execution was requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959f9d3848c832c8770bb22d2636daa)